### PR TITLE
Enhance frontend styling for home layout

### DIFF
--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -1,0 +1,81 @@
+:root {
+    color-scheme: light;
+}
+
+body.app-body {
+    min-height: 100vh;
+    background: radial-gradient(circle at top, #f8fbff 0%, #f3f6fb 45%, #eef2f7 100%);
+    color: #1f2a37;
+}
+
+.app-shell {
+    background: rgba(255, 255, 255, 0.75);
+    border-radius: 24px;
+    padding: 32px 28px 40px;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(6px);
+}
+
+.app-hero {
+    padding: 16px 0 8px;
+}
+
+.app-hero h1 {
+    letter-spacing: -0.02em;
+}
+
+.navbar.app-navbar {
+    background: #ffffff;
+}
+
+.navbar.app-navbar .navbar-brand {
+    font-weight: 600;
+    color: #1d4ed8;
+}
+
+.navbar.app-navbar .navbar-brand:hover {
+    color: #1e40af;
+}
+
+.app-link-list .list-group-item {
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: 16px;
+    padding: 16px 18px;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.app-link-list .list-group-item + .list-group-item {
+    margin-top: 12px;
+}
+
+.app-link-list .list-group-item:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+}
+
+.app-link-list a {
+    text-decoration: none;
+    color: inherit;
+    font-weight: 500;
+}
+
+.app-link-icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 12px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: #eef2ff;
+    color: #4338ca;
+    font-size: 18px;
+}
+
+#authActions .btn {
+    padding: 10px 24px;
+    border-radius: 999px;
+}
+
+footer.app-footer {
+    font-size: 0.9rem;
+}

--- a/src/main/resources/templates/base.html
+++ b/src/main/resources/templates/base.html
@@ -9,11 +9,12 @@
           href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
           integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
           rel="stylesheet">
+    <link href="/css/app.css" rel="stylesheet">
 </head>
-<body>
+<body class="app-body">
 
 <!-- 🌐 NAVBAR -->
-<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+<nav class="navbar navbar-expand-lg app-navbar shadow-sm mb-4">
     <div class="container">
         <a class="navbar-brand" href="/">← Back to Home</a>
     </div>
@@ -21,16 +22,21 @@
 
 <!-- 📦 CONTENT -->
 <div class="container mt-4">
-    <h1 class="text-center mb-4">GHKG App</h1>
+    <div class="app-shell">
+        <header class="app-hero text-center">
+            <h1 class="display-6 fw-semibold mb-2">GHKG App</h1>
+            <p class="text-muted mb-0">Manage trips, garages, and your account with ease.</p>
+        </header>
 
-    <main layout:fragment="content">
-        <!-- default content -->
-        <p>Welcome</p>
-    </main>
+        <main layout:fragment="content" class="mt-4">
+            <!-- default content -->
+            <p>Welcome</p>
+        </main>
 
-    <footer class="text-muted text-center mt-5">
-        <p>Version: <span th:text="${version}">unknown</span></p>
-    </footer>
+        <footer class="text-muted text-center mt-5 app-footer">
+            <p class="mb-0">Version: <span th:text="${version}">unknown</span></p>
+        </footer>
+    </div>
 </div>
 
 </body>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -7,13 +7,31 @@
 </head>
 <body>
 <main layout:fragment="content">
-    <ul class="list-group mb-4">
-        <li class="list-group-item" id="loginLink"><a href="/login">Login Page</a></li>
-        <li class="list-group-item" id="meLink" style="display: none;"><a href="/me">User Info</a></li>
-        <li class="list-group-item" id="adminLink" style="display: none;"><a href="/admin">Admin Panel</a></li>
-        <li class="list-group-item"><a href="/garage">Garage</a></li>
-        <li class="list-group-item"><a href="/trips">Trips</a></li>
-        <li class="list-group-item"><a href="/swagger-ui/index.html" target="_blank">Swagger UI</a></li>
+    <ul class="list-group app-link-list mb-4">
+        <li class="list-group-item d-flex align-items-center gap-3" id="loginLink">
+            <span class="app-link-icon">🔐</span>
+            <a href="/login">Login Page</a>
+        </li>
+        <li class="list-group-item d-flex align-items-center gap-3" id="meLink" style="display: none;">
+            <span class="app-link-icon">👤</span>
+            <a href="/me">User Info</a>
+        </li>
+        <li class="list-group-item d-flex align-items-center gap-3" id="adminLink" style="display: none;">
+            <span class="app-link-icon">🛠️</span>
+            <a href="/admin">Admin Panel</a>
+        </li>
+        <li class="list-group-item d-flex align-items-center gap-3">
+            <span class="app-link-icon">🚗</span>
+            <a href="/garage">Garage</a>
+        </li>
+        <li class="list-group-item d-flex align-items-center gap-3">
+            <span class="app-link-icon">🧭</span>
+            <a href="/trips">Trips</a>
+        </li>
+        <li class="list-group-item d-flex align-items-center gap-3">
+            <span class="app-link-icon">📘</span>
+            <a href="/swagger-ui/index.html" target="_blank" rel="noopener">Swagger UI</a>
+        </li>
     </ul>
 
     <div class="text-center mb-3" id="authActions"></div>


### PR DESCRIPTION
### Motivation
- Improve the visual design of the front page and provide a lightweight, consistent app shell for content.
- Make the home navigation more engaging and clearer to users by using iconized, card-like link items.

### Description
- Add a new stylesheet `src/main/resources/static/css/app.css` containing background, shell, navbar, link card and utility styles. 
- Include the stylesheet in `base.html` and add `class="app-body"` to the `body` to apply the global theme. 
- Restructure the base layout in `base.html` to wrap page content in an `.app-shell`, introduce an `.app-hero` header and adjust the footer presentation. 
- Update `index.html` to use `.app-link-list` with icon badges and a flexible, card-like layout for each navigation item and add `rel="noopener"` for the external Swagger link.

### Testing
- Attempted to run the application with `./mvnw -q spring-boot:run`, but it failed due to `Network is unreachable` while the Maven wrapper tried to download, so the app could not be started for live verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696a9d0e5b148331bb34a45b3d91ad04)